### PR TITLE
feat: Add commands to get/set message queue rlimit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,8 @@ name = "mq"
 version = "0.1.0"
 dependencies = [
  "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "posix_mq 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.1.0"
 authors = ["Vincent Ambo <tazjin@gmail.com>"]
 
 [dependencies]
-posix_mq = "0.1.1"
 clap = "2.26.2"
+libc = "0.2.32"
+nix = "0.9.0"
+posix_mq = "0.1.1"


### PR DESCRIPTION
When creating a large number of queues the message queue rlimit may be
reached (see mq_overview for details).

This commit adds an `mq rlimit` function that displays the current
rlimits and an optional `--rlimit` flag to the `create` command that
can raise the rlimit when required.